### PR TITLE
Add optional option --output where ng-manifest.json should be placed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Generate JSON manifest based on Angular build artifacts
 
 ## Usage 
 
-`ng-manifest --root <ANGULAR_PROJECT_ROOT_DIR>`
+```
+$ ng-manifest --root <ANGULAR_PROJECT_ROOT_DIR>
+
+Options:
+--root   [required] Angular project root
+--output [optional] Output directory. Default ${root}/dist
+```
 
 ## Output
 

--- a/bin/ng-manifest.js
+++ b/bin/ng-manifest.js
@@ -5,13 +5,14 @@
 const glob = require('glob-promise')
 const fs = require('fs')
 const {join} = require('path')
+const argv = require('minimist')
 
 ;(async () => {
 
     const STATS_FILENAME = 'ng-manifest.json'
 
-    const projectRoot = process.argv[3]
-    if (!projectRoot) {
+    const {root, output} = argv(process.argv)
+    if (!root) {
         throw new Error('--root param is required!')
     }
 
@@ -19,7 +20,7 @@ const {join} = require('path')
         absolute: false
     }
 
-    const projectPath = join(process.cwd(), projectRoot)
+    const projectPath = join(process.cwd(), root)
     const data = await glob(`${projectPath}/dist/**/+(*.js|*.css)`, options)
 
     const fileNames = data.map(path => {
@@ -63,7 +64,7 @@ const {join} = require('path')
         }
     }
 
-    const statsPath = join(projectPath, 'dist', STATS_FILENAME)
+    const statsPath = join(...(output ? [output] : [projectPath, 'dist']), STATS_FILENAME)
     fs.writeFile(statsPath, JSON.stringify(bundles, null, 2), err => {
         if (err) {
             console.error(err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "http://nexus.srinternal.net/nexus/repository/npm-all/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "glob": "7.1.6",
-    "glob-promise": "3.4.0"
+    "glob-promise": "3.4.0",
+    "minimist": "1.2.5"
   }
 }


### PR DESCRIPTION
Add optional option `--output` where `ng-manifest.json` should be placed.

The code kept as simple as possible.

**Reason:**
In code structured as bellow, I want to build manifest for client app and consume it directly in server app without additional procedures.

<img width="150" alt="Screen Shot 2020-04-07 at 12 20 34 AM" src="https://user-images.githubusercontent.com/4352707/78610744-cfb50b00-7865-11ea-90e8-22e4b52c1a2e.png">

Sample usage:
`npx ng-manifest --root=client --output=./server/tmp`
